### PR TITLE
fix(ci): inline local composite actions in on_new_pr.yml for pull_request_target

### DIFF
--- a/.github/workflows/on_new_pr.yml
+++ b/.github/workflows/on_new_pr.yml
@@ -6,6 +6,11 @@ on:
   # could and should work, at least for public repos;
   # tracking issue for this action's issue:
   # https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/60
+  # NOTE: pull_request_target resolves local composite actions from the filesystem rather than git
+  # storage, and since the workspace is empty at job initialisation (before any steps run), local
+  # uses: ./.github/actions/... references will always fail — even with an actions/checkout step,
+  # because step execution happens after action path resolution. As a result, any steps in this
+  # workflow that would otherwise use local composite actions must inline their logic directly.
   pull_request_target:
     types:
       - opened
@@ -29,10 +34,33 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - name: "Auto Merge"
-        uses: ./.github/actions/enable-automerge
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{secrets.SOURCE_PUSH_TOKEN}}
-          merge-method: "MERGE"
+          script: |
+            const mergeMethod = process.env.MERGE_METHOD;
+            const nodeId = context.payload.pull_request.node_id;
+            await github.graphql(`
+              mutation EnableAutoMerge($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                enablePullRequestAutoMerge(input: {
+                  pullRequestId: $pullRequestId,
+                  mergeMethod: $mergeMethod
+                }) {
+                  pullRequest {
+                    autoMergeRequest {
+                      mergeMethod
+                    }
+                  }
+                }
+              }
+            `, {
+              pullRequestId: nodeId,
+              mergeMethod: mergeMethod,
+            });
+            core.info(`✅ Enabled auto-merge (${mergeMethod}) on PR #${context.payload.pull_request.number}`);
+            core.notice(`Enabled auto-merge (${mergeMethod}) on PR #${context.payload.pull_request.number}`);
+        env:
+          MERGE_METHOD: "MERGE"
 
   auto_approve_dependabot:
     runs-on: ubuntu-latest
@@ -44,6 +72,15 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
       - name: "Auto Approve"
-        uses: ./.github/actions/approve-pr
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{secrets.SOURCE_PUSH_TOKEN}}
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE',
+            });
+            core.info(`✅ Approved PR #${context.payload.pull_request.number}`);
+            core.notice(`Approved PR #${context.payload.pull_request.number}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Unit tests for Credfeto.DotNet.Code.Analysis.Overrides.Cmd
 - Increased code coverage to 100% for Credfeto.DotNet.Code.Analysis.Overrides
 ### Fixed
+- Fixed CI workflows that use pull_request_target to inline local composite action logic rather than referencing .github/actions paths which cannot be resolved before checkout
 ### Changed
 - SDK - Updated DotNet SDK to 10.0.300
 ### Deprecated


### PR DESCRIPTION
## Summary

- `on_new_pr.yml` uses `pull_request_target` and referenced local composite actions via `uses: ./.github/actions/enable-automerge` and `uses: ./.github/actions/approve-pr`
- With `pull_request_target`, GitHub resolves local action paths at job initialisation time — before checkout — so these always fail with `Can't find action.yml`
- This caused `enable-auto-merge` and `auto_approve_dependabot` CI jobs to fail on every Dependabot PR (e.g. #27)
- Fix: inline the logic directly using `actions/github-script@v9.0.0`, matching the approach already used in `approve-dependabot.yml`
- Template issue raised in credfeto/cs-template#868

## Test plan

- [ ] Push triggers `Pull Request` workflow — `enable-auto-merge` and `auto_approve_dependabot` jobs should pass (or skip if `dependencies` label not present) without `Can't find action.yml` error
- [ ] Re-trigger PR #27 checks to verify the fix resolves the CI failures there