### PR TITLE
fix: ruleset command returns non-zero exit code when a rule is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Increased code coverage to 100% for Credfeto.DotNet.Code.Analysis.Overrides
 ### Fixed
 - Fixed InternalsVisibleTo declared via csproj AssemblyAttribute item, which violated the MustNotUseAssemblyAttributeItems build check
+- ruleset command now exits non-zero when a changes-file rule is missing from the target ruleset
 ### Changed
 - SDK - Updated DotNet SDK to 10.0.302
 ### Deprecated

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests/CommandsTests.cs
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests/CommandsTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Constants;
 using FunFair.Test.Common;
 using Xunit;
 
@@ -22,7 +23,12 @@ public sealed class CommandsTests : IntegrationTestBase
 
         try
         {
-            await commands.UpdateRulesetAsync(rulesetFileName: "non-existent.ruleset", changesFileName: changesFile);
+            int exitCode = await commands.UpdateRulesetAsync(
+                rulesetFileName: "non-existent.ruleset",
+                changesFileName: changesFile
+            );
+
+            Assert.Equal(ExitCodes.Success, exitCode);
         }
         finally
         {
@@ -31,7 +37,7 @@ public sealed class CommandsTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task UpdateRulesetAsync_WithChangesNoMatchingRule_DoesNotSave()
+    public async Task UpdateRulesetAsync_WithChangesNoMatchingRule_DoesNotSaveAndReturnsErrorExitCode()
     {
         Commands commands = new(this.GetTypedLogger<Commands>());
         CancellationToken cancellationToken = this.CancellationToken();
@@ -46,7 +52,12 @@ public sealed class CommandsTests : IntegrationTestBase
 
         try
         {
-            await commands.UpdateRulesetAsync(rulesetFileName: rulesetFile, changesFileName: changesFile);
+            int exitCode = await commands.UpdateRulesetAsync(
+                rulesetFileName: rulesetFile,
+                changesFileName: changesFile
+            );
+
+            Assert.Equal(ExitCodes.Error, exitCode);
         }
         finally
         {
@@ -56,7 +67,7 @@ public sealed class CommandsTests : IntegrationTestBase
     }
 
     [Fact]
-    public async Task UpdateRulesetAsync_WithChangesMatchingRule_SavesUpdatedRuleset()
+    public async Task UpdateRulesetAsync_WithChangesMatchingRule_SavesUpdatedRulesetAndReturnsSuccessExitCode()
     {
         Commands commands = new(this.GetTypedLogger<Commands>());
         CancellationToken cancellationToken = this.CancellationToken();
@@ -71,7 +82,50 @@ public sealed class CommandsTests : IntegrationTestBase
 
         try
         {
-            await commands.UpdateRulesetAsync(rulesetFileName: rulesetFile, changesFileName: changesFile);
+            int exitCode = await commands.UpdateRulesetAsync(
+                rulesetFileName: rulesetFile,
+                changesFileName: changesFile
+            );
+
+            Assert.Equal(ExitCodes.Success, exitCode);
+
+            string saved = await File.ReadAllTextAsync(path: rulesetFile, cancellationToken: cancellationToken);
+            Assert.Contains("Warning", saved, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteIfExists(changesFile);
+            DeleteIfExists(rulesetFile);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateRulesetAsync_WithOneMatchingAndOneMissingRule_SavesAndReturnsErrorExitCode()
+    {
+        Commands commands = new(this.GetTypedLogger<Commands>());
+        CancellationToken cancellationToken = this.CancellationToken();
+        string changesFile = await WriteJsonTempAsync(
+            content: """
+            [
+              {"ruleSet":"TestAnalyzer","rule":"TEST001","state":"Warning","description":"Test Rule"},
+              {"ruleSet":"TestAnalyzer","rule":"MISSING001","state":"Warning","description":"Missing Rule"}
+            ]
+            """,
+            cancellationToken: cancellationToken
+        );
+        string rulesetFile = await WriteXmlTempAsync(
+            content: """<RuleSet Name="Test" ToolsVersion="16.0"><Rules AnalyzerId="TestAnalyzer"><Rule Id="TEST001" Action="None" /></Rules></RuleSet>""",
+            cancellationToken: cancellationToken
+        );
+
+        try
+        {
+            int exitCode = await commands.UpdateRulesetAsync(
+                rulesetFileName: rulesetFile,
+                changesFileName: changesFile
+            );
+
+            Assert.Equal(ExitCodes.Error, exitCode);
 
             string saved = await File.ReadAllTextAsync(path: rulesetFile, cancellationToken: cancellationToken);
             Assert.Contains("Warning", saved, StringComparison.Ordinal);

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd/Commands.cs
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd/Commands.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Cocona;
+using Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Constants;
 using Credfeto.DotNet.Code.Analysis.Overrides.Cmd.LoggingExtensions;
 using Credfeto.DotNet.Code.Analysis.Overrides.Helpers;
 using Credfeto.DotNet.Code.Analysis.Overrides.Ini;
@@ -39,7 +40,7 @@ internal sealed class Commands
 
     [Command("ruleset", Description = "Update codeanalysiis.ruleset")]
     [SuppressMessage(category: "ReSharper", checkId: "UnusedMember.Global", Justification = "Used by Cocona")]
-    public async Task UpdateRulesetAsync(
+    public async Task<int> UpdateRulesetAsync(
         [Option(name: "ruleset", ['r'], Description = "ruleset file to change")] string rulesetFileName,
         [Option(name: "changes", ['c'], Description = "file of changes to apply")] string changesFileName
     )
@@ -50,29 +51,33 @@ internal sealed class Commands
         {
             this._logger.NoChangesInFile(changesFileName);
 
-            return;
+            return ExitCodes.Success;
         }
 
         bool changed = false;
+        bool ruleNotPresent = false;
         XmlDocument ruleSet = await RuleSet.LoadAsync(rulesetFileName);
 
         foreach (RuleChange change in changes)
         {
             this._logger.ChangingState(change.RuleSet, rule: change.Rule, change.State);
-            bool hasChanged = ruleSet.ChangeValue(
+            RuleChangeOutcome outcome = ruleSet.ChangeValue(
                 ruleSet: change.RuleSet,
                 rule: change.Rule,
                 name: change.Description,
                 newState: change.State,
                 logger: this._logger
             );
-            changed |= hasChanged;
+            changed |= outcome == RuleChangeOutcome.Changed;
+            ruleNotPresent |= outcome == RuleChangeOutcome.RuleNotPresent;
         }
 
         if (changed)
         {
             await RuleSet.SaveAsync(rulesetFileName, ruleSet);
         }
+
+        return ruleNotPresent ? ExitCodes.Error : ExitCodes.Success;
     }
 
     [Command("globalconfig", Description = "Update .globalconfig")]

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides.Tests/XmlUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides.Tests/XmlUpdaterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml;
 using Credfeto.DotNet.Code.Analysis.Overrides;
+using Credfeto.DotNet.Code.Analysis.Overrides.Models;
 using FunFair.Test.Common;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -39,11 +40,11 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
     }
 
     [Fact]
-    public void ChangeValueReturnsFalseWhenRuleNotPresent()
+    public void ChangeValueReturnsRuleNotPresentWhenRuleNotPresent()
     {
         XmlDocument doc = CreateEmptyXmlDocument();
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "MyAnalyzer",
             rule: "MA0001",
             name: "Some Rule",
@@ -51,15 +52,15 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.False(changed, "Should return false when rule is not present");
+        Assert.Equal(RuleChangeOutcome.RuleNotPresent, outcome);
     }
 
     [Fact]
-    public void ChangeValueReturnsFalseWhenExistingActionIsIdentical()
+    public void ChangeValueReturnsUnchangedWhenExistingActionIsIdentical()
     {
         XmlDocument doc = CreateXmlDocumentWithRule(ruleSet: "MyAnalyzer", rule: "MA0001", action: "error");
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "MyAnalyzer",
             rule: "MA0001",
             name: "Some Rule",
@@ -67,15 +68,15 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.False(changed, "Should return false when existing action is identical");
+        Assert.Equal(RuleChangeOutcome.Unchanged, outcome);
     }
 
     [Fact]
-    public void ChangeValueReturnsTrueWhenActionDiffers()
+    public void ChangeValueReturnsChangedWhenActionDiffers()
     {
         XmlDocument doc = CreateXmlDocumentWithRule(ruleSet: "MyAnalyzer", rule: "MA0001", action: "none");
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "MyAnalyzer",
             rule: "MA0001",
             name: "Some Rule",
@@ -83,7 +84,7 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.True(changed, "Should return true when action differs");
+        Assert.Equal(RuleChangeOutcome.Changed, outcome);
     }
 
     [Fact]
@@ -91,7 +92,7 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
     {
         XmlDocument doc = CreateXmlDocumentWithRule(ruleSet: "MyAnalyzer", rule: "MA0001", action: "none");
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "MyAnalyzer",
             rule: "MA0001",
             name: "Some Rule",
@@ -99,7 +100,7 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.True(changed, "Should return true when action is updated");
+        Assert.Equal(RuleChangeOutcome.Changed, outcome);
 
         XmlElement? element =
             doc.SelectSingleNode("//RuleSet/Rules[@AnalyzerId='MyAnalyzer']/Rule[@Id='MA0001']") as XmlElement;
@@ -108,11 +109,11 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
     }
 
     [Fact]
-    public void ChangeValueDoesNotUpdateWhenRuleSetDoesNotMatch()
+    public void ChangeValueReturnsRuleNotPresentWhenRuleSetDoesNotMatch()
     {
         XmlDocument doc = CreateXmlDocumentWithRule(ruleSet: "OtherAnalyzer", rule: "MA0001", action: "none");
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "MyAnalyzer",
             rule: "MA0001",
             name: "Some Rule",
@@ -120,15 +121,15 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.False(changed, "Should return false when ruleSet does not match");
+        Assert.Equal(RuleChangeOutcome.RuleNotPresent, outcome);
     }
 
     [Fact]
-    public void ChangeValueDoesNotUpdateWhenRuleIdDoesNotMatch()
+    public void ChangeValueReturnsRuleNotPresentWhenRuleIdDoesNotMatch()
     {
         XmlDocument doc = CreateXmlDocumentWithRule(ruleSet: "MyAnalyzer", rule: "MA9999", action: "none");
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "MyAnalyzer",
             rule: "MA0001",
             name: "Some Rule",
@@ -136,15 +137,15 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.False(changed, "Should return false when rule ID does not match");
+        Assert.Equal(RuleChangeOutcome.RuleNotPresent, outcome);
     }
 
     [Fact]
-    public void ChangeValueReturnsTrueAndSetsNewStateForDifferentAction()
+    public void ChangeValueReturnsChangedAndSetsNewStateForDifferentAction()
     {
         XmlDocument doc = CreateXmlDocumentWithRule(ruleSet: "AnalyzerX", rule: "AX001", action: "suggestion");
 
-        bool changed = doc.ChangeValue(
+        RuleChangeOutcome outcome = doc.ChangeValue(
             ruleSet: "AnalyzerX",
             rule: "AX001",
             name: "Rule AX001",
@@ -152,7 +153,7 @@ public sealed class XmlUpdaterTests : IntegrationTestBase
             logger: this._logger
         );
 
-        Assert.True(changed, "Should return true when action is changed");
+        Assert.Equal(RuleChangeOutcome.Changed, outcome);
 
         XmlElement? element =
             doc.SelectSingleNode("//RuleSet/Rules[@AnalyzerId='AnalyzerX']/Rule[@Id='AX001']") as XmlElement;

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides/Models/RuleChangeOutcome.cs
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides/Models/RuleChangeOutcome.cs
@@ -1,0 +1,8 @@
+namespace Credfeto.DotNet.Code.Analysis.Overrides.Models;
+
+public enum RuleChangeOutcome
+{
+    Unchanged,
+    Changed,
+    RuleNotPresent,
+}

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides/XmlUpdater.cs
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides/XmlUpdater.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Xml;
 using Credfeto.DotNet.Code.Analysis.Overrides.LoggingExtensions;
+using Credfeto.DotNet.Code.Analysis.Overrides.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Credfeto.DotNet.Code.Analysis.Overrides;
 
 public static class XmlUpdater
 {
-    public static bool ChangeValue(
+    public static RuleChangeOutcome ChangeValue(
         this XmlDocument xmlRuleSet,
         string ruleSet,
         string rule,
@@ -23,7 +24,7 @@ public static class XmlUpdater
         {
             logger.RuleNotPresent(ruleSet: ruleSet, rule: rule, name: name);
 
-            return false;
+            return RuleChangeOutcome.RuleNotPresent;
         }
 
         string existingValue = element.GetAttribute("Action");
@@ -32,7 +33,7 @@ public static class XmlUpdater
         {
             logger.RuleNotChangedAsIdentical(ruleSet: ruleSet, rule: rule, name: name, setting: existingValue);
 
-            return false;
+            return RuleChangeOutcome.Unchanged;
         }
 
         element.SetAttribute(name: "Action", value: newState);
@@ -44,6 +45,6 @@ public static class XmlUpdater
             newSetting: newState
         );
 
-        return true;
+        return RuleChangeOutcome.Changed;
     }
 }


### PR DESCRIPTION
## Summary

`XmlUpdater.ChangeValue` logs `RuleNotPresent` at `LogLevel.Error` when a rule from the changes file does not exist in the `.ruleset`, but `Commands.UpdateRulesetAsync` carries on and the process exits 0 regardless. `ExitCodes` (`Success`/`Error`) is defined but never referenced anywhere except its own test.

This PR implements the plan agreed on issue #45:

- Introduce a `RuleChangeOutcome` enum (`Unchanged` / `Changed` / `RuleNotPresent`) as `XmlUpdater.ChangeValue`'s return type instead of `bool`.
- `Commands.UpdateRulesetAsync` becomes `Task<int>`, aggregating outcomes across the loop and returning `ExitCodes.Error` if any `RuleNotPresent` occurred, else `ExitCodes.Success`.
- `UpdateGlobalConfigAsync` is left unchanged (the `.globalconfig` path adds missing rules rather than failing, so there's no equivalent error condition today).
- Update `XmlUpdaterTests` and `CommandsTests` accordingly, including a new test asserting `ExitCodes.Error` for the missing-rule case.

This draft PR currently only contains a placeholder CHANGELOG entry; the implementation follows in subsequent commits on this branch.

Closes #45