### PR TITLE
chore: drop net9.0, target net10.0 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -15,6 +18,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - ruleset command now exits non-zero when a changes-file rule is missing from the target ruleset
 ### Changed
 - SDK - Updated DotNet SDK to 10.0.302
+- Drop net9.0 target framework support; target net10.0 only (#51)
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests.csproj
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests.csproj
@@ -38,7 +38,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-codeanalysis-override</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.csproj
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.csproj
@@ -46,7 +46,7 @@
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <ToolCommandName>code-analysis</ToolCommandName>

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides.Tests/Credfeto.DotNet.Code.Analysis.Overrides.Tests.csproj
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides.Tests/Credfeto.DotNet.Code.Analysis.Overrides.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Code.Analysis.Overrides/Credfeto.DotNet.Code.Analysis.Overrides.csproj
+++ b/src/Credfeto.DotNet.Code.Analysis.Overrides/Credfeto.DotNet.Code.Analysis.Overrides.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-codeanalysis-override</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />
@@ -60,8 +60,8 @@
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Editorconfig" Version="0.15.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" ExcludeAssets="runtime" />


### PR DESCRIPTION
## Summary

Drops `net9.0` from all multi-targeted projects so the repository targets `net10.0` only, per the approved implementation plan on #51.

### Files to change

A fresh repo-wide grep for `<TargetFrameworks>net9.0;net10.0</TargetFrameworks>` at the start of this work found **4** matching files, one more than the 3 listed in the approved plan comment on #51 (`Credfeto.DotNet.Code.Analysis.Overrides.Cmd.csproj` was missing from the plan's list). The issue itself calls this out as a possibility ("Treat this as a repository-wide rule ... not a fixed file list ... may have drifted"), so the grep result is treated as authoritative:

- `src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.Tests.csproj`
- `src/Credfeto.DotNet.Code.Analysis.Overrides.Cmd/Credfeto.DotNet.Code.Analysis.Overrides.Cmd.csproj` (not in the original plan's list; picked up by the repo-wide grep)
- `src/Credfeto.DotNet.Code.Analysis.Overrides.Tests/Credfeto.DotNet.Code.Analysis.Overrides.Tests.csproj`
- `src/Credfeto.DotNet.Code.Analysis.Overrides/Credfeto.DotNet.Code.Analysis.Overrides.csproj`

Each currently has `<TargetFrameworks>net9.0;net10.0</TargetFrameworks>`, to be replaced with a single `<TargetFramework>net10.0</TargetFramework>`.

No `net9.0`-specific MSBuild `Condition`s or `#if NET9_0` (non-`_OR_GREATER`) guards were found in source; only generated `obj/` artifacts reference `net9.0`. `global.json` is already pinned to a net10.0 SDK, so no change needed there.

This PR currently contains only a placeholder CHANGELOG.md entry; the code change lands in a follow-up commit under the PR workflow.

Closes #51